### PR TITLE
Node modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 .git
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Ignore `node_modules` for Docker and git, connecting to [this Gitter conversation](https://gitter.im/resin-os/chat?at=584460a6f666c5a138cc3c10).